### PR TITLE
Change save animation on cookies page

### DIFF
--- a/css/eu-cookie-compliance.css
+++ b/css/eu-cookie-compliance.css
@@ -15,7 +15,7 @@
     right: 6px;
     top: 50%;
     box-shadow: 0 0 0 1px rgba(255, 0, 0, 0.1);
-    border-right: 3px solid var(--color-accent);
+    border-right: 3px solid var(--button-text-color-hover);
     animation: rotate360 .5s infinite linear, space .1s forwards ease;
 }
 

--- a/css/eu-cookie-compliance.css
+++ b/css/eu-cookie-compliance.css
@@ -14,8 +14,11 @@
     border-radius: 50%;
     right: 6px;
     top: 50%;
+    box-shadow: 0 0 2px 0 white;
+    border-right: 3px solid white;
+    /* Set these override rules if you're using the LGD base theme.
     box-shadow: 0 0 2px 0 var(--button-text-color-hover);
-    border-right: 3px solid var(--button-text-color-hover);
+    border-right: 3px solid var(--button-text-color-hover);*/
     animation: rotate360 .5s infinite linear, space .1s forwards ease;
 }
 

--- a/css/eu-cookie-compliance.css
+++ b/css/eu-cookie-compliance.css
@@ -14,7 +14,7 @@
     border-radius: 50%;
     right: 6px;
     top: 50%;
-    box-shadow: 0 0 0 1px rgba(255, 0, 0, 0.1);
+    box-shadow: 0 0 2px 0 var(--button-text-color-hover);
     border-right: 3px solid var(--button-text-color-hover);
     animation: rotate360 .5s infinite linear, space .1s forwards ease;
 }

--- a/css/eu-cookie-compliance.css
+++ b/css/eu-cookie-compliance.css
@@ -16,9 +16,6 @@
     top: 50%;
     box-shadow: 0 0 2px 0 white;
     border-right: 3px solid white;
-    /* Set these override rules if you're using the LGD base theme.
-    box-shadow: 0 0 2px 0 var(--button-text-color-hover);
-    border-right: 3px solid var(--button-text-color-hover);*/
     animation: rotate360 .5s infinite linear, space .1s forwards ease;
 }
 

--- a/css/eu-cookie-compliance.css
+++ b/css/eu-cookie-compliance.css
@@ -6,7 +6,7 @@
     padding-right: 40px;
 }
 
-.eu-cookie-compliance-save-preferences-button.spinning:before {
+.eu-cookie-compliance-save-preferences-button.spinning::before {
     content: "";
     position: absolute;
     width: 0px;

--- a/css/save-animation.css
+++ b/css/save-animation.css
@@ -1,0 +1,34 @@
+.eu-cookie-compliance-save-preferences-button {
+    position: relative;
+}
+
+.eu-cookie-compliance-save-preferences-button.spinning {
+    padding-right: 40px;
+}
+
+.eu-cookie-compliance-save-preferences-button.spinning:before {
+    content: "";
+    position: absolute;
+    width: 0px;
+    height: 0px;
+    border-radius: 50%;
+    right: 6px;
+    top: 50%;
+    box-shadow: 0 0 0 1px rgba(255, 0, 0, 0.1);
+    border-right: 3px solid var(--color-accent);
+    animation: rotate360 .5s infinite linear, space .1s forwards ease;
+}
+
+@keyframes rotate360 {
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes space {
+    100% {
+        margin: -8px 5px 0 0;
+        width: 15px;
+        height: 15px;
+    }
+}

--- a/js/localgov_eu_cookie_compliance.es6.js
+++ b/js/localgov_eu_cookie_compliance.es6.js
@@ -103,10 +103,24 @@
    * Provide feedback when the "Save cookie settings" button is clicked.
    */
   function setupSaveSettingsFeedback() {
-    $(".eu-cookie-compliance-save-preferences-button").click(e => {
-      $(`<p>${Drupal.t("Saved")}</p>`)
-        .appendTo(e.target)
-        .hide(2000);
-    });
+    var saveButton = document.querySelector('.eu-cookie-compliance-save-preferences-button');
+    const saveButtonLabel = saveButton.innerHTML;
+
+    saveButton.addEventListener("click", function () {
+      saveButton.innerHTML = `${Drupal.t("Saving")}`;
+      saveButton.classList.add('spinning');
+
+      setTimeout(
+        function () {
+          saveButton.classList.remove('spinning');
+          saveButton.innerHTML = `${Drupal.t("Preferences saved")}  <i class="fas fa-check"></i>`;
+        }, 2000);
+
+    }, false);
+
+    saveButton.addEventListener("blur", function () {
+      saveButton.innerHTML = saveButtonLabel;
+    }, false);
+
   }
 })(jQuery, Drupal);

--- a/js/localgov_eu_cookie_compliance.es6.js
+++ b/js/localgov_eu_cookie_compliance.es6.js
@@ -103,7 +103,7 @@
    * Provide feedback when the "Save cookie settings" button is clicked.
    */
   function setupSaveSettingsFeedback() {
-    var saveButton = document.querySelector('.eu-cookie-compliance-save-preferences-button');
+    const saveButton = document.querySelector('.eu-cookie-compliance-save-preferences-button');
     const saveButtonLabel = saveButton.innerHTML;
 
     saveButton.addEventListener("click", function () {

--- a/js/localgov_eu_cookie_compliance.js
+++ b/js/localgov_eu_cookie_compliance.js
@@ -38,8 +38,21 @@
     });
   }
   function setupSaveSettingsFeedback() {
-    $(".eu-cookie-compliance-save-preferences-button").click(function (e) {
-      $("<p>".concat(Drupal.t("Saved"), "</p>")).appendTo(e.target).hide(2000);
-    });
+    var saveButton = document.querySelector('.eu-cookie-compliance-save-preferences-button');
+    const saveButtonLabel = saveButton.innerHTML;
+
+    saveButton.addEventListener("click", function () {
+      saveButton.innerHTML = `${Drupal.t("Saving")}`;
+      saveButton.classList.add('spinning');
+
+      setTimeout(function () {
+        saveButton.classList.remove('spinning');
+        saveButton.innerHTML = `${Drupal.t("Preferences saved")}  <i class="fas fa-check"></i>`;
+      }, 2000);
+    }, false);
+
+    saveButton.addEventListener("blur", function () {
+      saveButton.innerHTML = saveButtonLabel;
+    }, false);
   }
 })(jQuery, Drupal);

--- a/js/localgov_eu_cookie_compliance.js
+++ b/js/localgov_eu_cookie_compliance.js
@@ -4,41 +4,51 @@
 * https://www.drupal.org/node/2815083
 * @preserve
 **/
+
 (function setupCookieSettingsBlock($, Drupal) {
   Drupal.behaviors.activateCookieSettingsForm = {
-    attach: function attach(context) {
-      var selectedCookieCategories = Drupal.eu_cookie_compliance.getAcceptedCategories();
+    attach(context) {
+      const selectedCookieCategories = Drupal.eu_cookie_compliance.getAcceptedCategories();
+
       Drupal.eu_cookie_compliance.setAcceptedCategories(selectedCookieCategories);
       Drupal.eu_cookie_compliance.loadCategoryScripts(selectedCookieCategories);
+
       Drupal.eu_cookie_compliance.setPreferenceCheckboxes(selectedCookieCategories);
       Drupal.eu_cookie_compliance.attachSavePreferencesEvents();
+
       once("localgov-eu-cookie-compliance-radios", "#eu-cookie-compliance-categories", context).forEach(displayCheckboxAsRadios);
     }
   };
+
   function displayCheckboxAsRadios() {
-    setTimeout(function () {
+    setTimeout(() => {
       hideCheckboxes();
       clickRadiosBasedOnCheckboxStatus();
       setupUpClickHandlersForRadios();
       setupSaveSettingsFeedback();
     }, 300);
   }
+
   function hideCheckboxes() {
     $("[name=cookie-categories]:checkbox").hide();
   }
+
   function clickRadiosBasedOnCheckboxStatus() {
     $("[name=cookie-categories]:checked + .eu-cookie-compliance-categories--on :radio:not(:checked)").prop("checked", true);
     $("[name=cookie-categories]:not(:checked) + .eu-cookie-compliance-categories--on + .eu-cookie-compliance-categories--off :radio:not(:checked)").prop("checked", true);
   }
+
   function setupUpClickHandlersForRadios() {
-    $(".eu-cookie-compliance-categories--on :radio, .eu-cookie-compliance-categories--off :radio").click(function (event) {
-      var key = event.target.value;
-      var relatedCheckboxId = "cookie-category-".concat(key);
-      $("#".concat(relatedCheckboxId)).click();
+    $(".eu-cookie-compliance-categories--on :radio, .eu-cookie-compliance-categories--off :radio").click(event => {
+      const key = event.target.value;
+      const relatedCheckboxId = `cookie-category-${key}`;
+
+      $(`#${relatedCheckboxId}`).click();
     });
   }
+
   function setupSaveSettingsFeedback() {
-    var saveButton = document.querySelector('.eu-cookie-compliance-save-preferences-button');
+    const saveButton = document.querySelector('.eu-cookie-compliance-save-preferences-button');
     const saveButtonLabel = saveButton.innerHTML;
 
     saveButton.addEventListener("click", function () {

--- a/localgov_eu_cookie_compliance.libraries.yml
+++ b/localgov_eu_cookie_compliance.libraries.yml
@@ -3,7 +3,7 @@ localgov_eu_cookie_compliance:
     js/localgov_eu_cookie_compliance.js: {}
   css:
     theme:
-      css/save-animation.css: {}
+      css/eu-cookie-compliance.css: {}
   dependencies:
     - eu_cookie_compliance/eu_cookie_compliance_bare
 

--- a/localgov_eu_cookie_compliance.libraries.yml
+++ b/localgov_eu_cookie_compliance.libraries.yml
@@ -1,6 +1,9 @@
 localgov_eu_cookie_compliance:
   js:
     js/localgov_eu_cookie_compliance.js: {}
+  css:
+    theme:
+      css/save-animation.css: {}
   dependencies:
     - eu_cookie_compliance/eu_cookie_compliance_bare
 


### PR DESCRIPTION
The current save animation causes the save button to expand with additional text, then ease back to the original. This replaces the button contents with a saving message that causes less visual disturbance.

The current version appears as:
![croydon](https://user-images.githubusercontent.com/98908/222109806-54b7762b-8774-4eb6-8b39-35250003d5a1.gif)

with this change it looks as follows:
![essex](https://user-images.githubusercontent.com/98908/222109872-865824d6-80fc-4a61-a843-164419d22add.gif)

*N.B.:* Differences in accent colour and other styling are due to this being captured on different sites, only the button behaviour is impacted.