### PR TITLE
Change categories on banner to hidden

### DIFF
--- a/templates/eu-cookie-compliance-popup-info--override.html.twig
+++ b/templates/eu-cookie-compliance-popup-info--override.html.twig
@@ -81,7 +81,7 @@
 
 {# This hidden markup is needed by Drupal.eu_cookie_compliance.setPreferenceCheckboxes() #}
 {% if cookie_categories %}
-  <div id="eu-cookie-compliance-categories" class="visually-hidden">
+  <div id="eu-cookie-compliance-categories" class="hidden">
     {% for key, category in cookie_categories %}
       <input type="checkbox" name="cookie-categories" id="cookie-category-{{ key }}" value="{{ key }}" {% if fix_first_cookie_category and loop.first %} checked disabled{% endif %}>
     {% endfor %}


### PR DESCRIPTION
Ref #1 

Changes the required category markup to use the hidden class instead of visually-hidden. This might fix the accessbility issue, but might also stop the categories from working (seems fine in my limited testing though).