### PR TITLE
Add oembed blocking functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - Extends the functionality of the [EU Cookie compliance contrib module](https://www.drupal.org/project/eu_cookie_compliance).
 - Provides a block containing the same content as the EU Cookie popup.  When this block is added to a page, we get a dedicated Cookie settings page.  At the time of writing in early 2023, many sites including the [BBC](https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/) use such a dedicated Cookie settings page.  This is the primary feature of this module.
 - Only relevant when you want users to have greater control over site cookies by enabling them to accept or reject certain types of cookies e.g. accept Functional cookies, reject Analytics cookies and so on.
+- Adds an embed management feature, to allow oembed videos to be restricted by domain according to cookie consent settings
 - <a name="secondary-feature"></a>The EU Cookie compliance module actually doesn't stop any cookie being set prior to consent.  What it does is, it removes unwanted cookies immediately after they are set.  The custom module improves up on this for Google analytics and Hotjar in a way that these modules would not even set any cookie in the browser prior to consent.  This is a secondary feature of this module.
 
 ## How to configure

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Provides a block containing the same content as the EU Cookie popup.  When this block is added to a page, we get a dedicated Cookie settings page.  At the time of writing in early 2023, many sites including the [BBC](https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/) use such a dedicated Cookie settings page.  This is the primary feature of this module.
 - Only relevant when you want users to have greater control over site cookies by enabling them to accept or reject certain types of cookies e.g. accept Functional cookies, reject Analytics cookies and so on.
 - Adds an embed management feature, to allow oembed videos to be restricted by domain according to cookie consent settings
-- <a name="secondary-feature"></a>The EU Cookie compliance module actually doesn't stop any cookie being set prior to consent.  What it does is, it removes unwanted cookies immediately after they are set.  The custom module improves up on this for Google analytics and Hotjar in a way that these modules would not even set any cookie in the browser prior to consent.  This is a secondary feature of this module.
+- <a name="secondary-feature"></a>The EU Cookie compliance module's cookie functionality actually doesn't stop any cookie being set prior to consent, rather it removes unauthorised cookies. On its own, this isn't sufficient for GDPR compliance, we need to use the Javascript blocking functionality also. Any modules that add their scripts directly to the head need to be customised to remove the scripts and have them replaced with a new loader script. This module includes pre-built loaders for Google Analytics and HotJar, as well as an integration to automatically remove them and make the HTML available to the loader. This makes it easier to create compliant sites using Google Analytics and Hotjar by including an integration to load those in a way compatible with the JS blocking function.
 
 ## How to configure
 - Create a content page (e.g. /foo) explaining your site Cookies.
@@ -16,6 +16,8 @@
   - Select **Opt-in with categories** as the consent method.
   - Add all your cookie categories to the **Cookie categories with separate consent** textbox.
   - Enter the cookie settings page path (e.g. /foo) to the **Cookie settings page path** textfield.  The default path is */cookies*.  Without this path, this module would not provide the category-wise Cookie settings form.
+  - If you are using the Google Analytics module, specify the consent options to load its scripts in **Disable Javascripts**. For example, `analytics:modules/contrib/localgov_eu_cookie_compliance/js/deferred-ga-script-runner.js||localgov_eu_cookie_compliance/deferred-scripts`
+  - If you are using the HotJar module, specify the consent options to load its scripts in **Disable Javascripts**. For example, `analytics:modules/contrib/localgov_eu_cookie_compliance/js/deferred-hotjar-script-runner.js||localgov_eu_cookie_compliance/deferred-scripts`
   - Consider updating the following textfields:
     - "Save preferences" button label
     - "Accept all categories" button label

--- a/js/localgov_eu_cookie_compliance.js
+++ b/js/localgov_eu_cookie_compliance.js
@@ -66,3 +66,4 @@
     }, false);
   }
 })(jQuery, Drupal);
+

--- a/js/oembed_cookies.js
+++ b/js/oembed_cookies.js
@@ -1,0 +1,28 @@
+
+/**
+ * @file
+ * ecc_oembed_cookies.js
+ *
+ * Defines the output of the oembed html field based on the consent of marketing cookies.
+ */
+(function ($, Drupal) {
+
+    Drupal.behaviors.cookiesVideoDisplay = {
+      attach: function(context, settings) {
+        // If this behaviour runs before eu_cookie_compliance is fully loaded, the
+        // internal _euccSelectedCategories variable may not have been set yet. This
+        // caches the accepted cookies. To ensure it is, we set that manually using
+        // the asymmetric getter/setter getAcceptedCategories.
+        Drupal.eu_cookie_compliance.setAcceptedCategories(Drupal.eu_cookie_compliance.getAcceptedCategories());
+        Drupal.eu_cookie_compliance.execute();
+
+        $.each(settings.ecc_cookie_oembed, function(key, val) {
+          if (val['video'] && Drupal.eu_cookie_compliance.hasAgreed(val['category'])) {
+            $('.media-oembed-'+key).html(val.video)
+          }
+        })
+  
+      }
+    }
+  
+  }) (jQuery, Drupal)

--- a/js/oembed_cookies.js
+++ b/js/oembed_cookies.js
@@ -1,7 +1,7 @@
 
 /**
  * @file
- * ecc_oembed_cookies.js
+ * oembed_cookies.js
  *
  * Defines the output of the oembed html field based on the consent of marketing cookies.
  */
@@ -10,14 +10,15 @@
     Drupal.behaviors.cookiesVideoDisplay = {
       attach: function(context, settings) {
         // If this behaviour runs before eu_cookie_compliance is fully loaded, the
-        // internal _euccSelectedCategories variable may not have been set yet. This
-        // caches the accepted cookies. To ensure it is, we set that manually using
-        // the asymmetric getter/setter getAcceptedCategories.
+        // internal _euccSelectedCategories and _euccCurrentStatus variables may not
+        // have been set yet. This caches the accepted cookies and mode. To ensure it
+        // is, we set that manually using the asymmetric getter/setter methods, which
+        // read the correct value but set it into the cache.
         Drupal.eu_cookie_compliance.setAcceptedCategories(Drupal.eu_cookie_compliance.getAcceptedCategories());
-        Drupal.eu_cookie_compliance.execute();
+        Drupal.eu_cookie_compliance.updateCurrentStatus(Drupal.eu_cookie_compliance.getCurrentStatus());
 
         $.each(settings.ecc_cookie_oembed, function(key, val) {
-          if (val['video'] && Drupal.eu_cookie_compliance.hasAgreed(val['category'])) {
+          if (val.video && Drupal.eu_cookie_compliance.hasAgreed(val.category)) {
             $('.media-oembed-'+key).html(val.video)
           }
         })

--- a/localgov_eu_cookie_compliance.libraries.yml
+++ b/localgov_eu_cookie_compliance.libraries.yml
@@ -1,3 +1,10 @@
+oembed_cookies:
+  version: VERSION
+  js:
+    js/oembed_cookies.js: {}
+  dependencies:
+    - core/jquery
+
 localgov_eu_cookie_compliance:
   js:
     js/localgov_eu_cookie_compliance.js: {}

--- a/localgov_eu_cookie_compliance.libraries.yml
+++ b/localgov_eu_cookie_compliance.libraries.yml
@@ -4,6 +4,7 @@ oembed_cookies:
     js/oembed_cookies.js: {}
   dependencies:
     - core/jquery
+    - eu_cookie_compliance/eu_cookie_compliance
 
 localgov_eu_cookie_compliance:
   js:

--- a/localgov_eu_cookie_compliance.module
+++ b/localgov_eu_cookie_compliance.module
@@ -116,10 +116,11 @@ function localgov_eu_cookie_compliance_form_eu_cookie_compliance_config_form_alt
     '#convert_path' => PathElement::CONVERT_NONE,
   ];
 
-
-  $form['oembed'] = [
+  // Insert the oembed management section.
+  // First, we define the section.
+  $section = [
     '#type' => 'details',
-    '#title' => t("Disable the following embed sources when consent isn't given"),
+    '#title' => t("Embed handling"),
     '#open' => TRUE,
     '#states' => [
       'visible' => [
@@ -128,32 +129,24 @@ function localgov_eu_cookie_compliance_form_eu_cookie_compliance_config_form_alt
     ],
   ];
 
+  // Then find where in the associative array the cookies section is, and
+  // splice the array so the new section is immediately after it in the
+  // implicit ordering. This prevents the new section being at the bottom
+  // of the form, and instead places it with logical siblings.
+  $offset = array_search("cookies", array_keys($form)) + 1;
+  $form = array_slice($form, 0, $offset, TRUE) +
+          ['oembed' => $section] +
+          array_slice($form, $offset, NULL, TRUE);
+
   $form['oembed']['disabled_oembeds'] = [
     '#type' => 'textarea',
     '#title' => t('Disable OEmbed sources'),
     '#default_value' => $config->get('disabled_oembeds'),
-    '#description' => t("<span class='eu-cookie-compliance-word-break'>Include the domain to block embeds from, each on a separate line. When using the opt-in or opt-out consent options, you can block certain oembed sources from being loaded when consent isn't given.<br><br> When using the consent method 'Opt-in with categories', you can link the script to a specific category by using the format: 'google_cookies:youtu.be'"),
+    '#description' => t("<span class='eu-cookie-compliance-word-break'>Include the domain to block embeds from, each on a separate line. You may use wildcards, such as <kbd>*youtube.com</kbd>. <br><br> When using the consent method 'Opt-in with categories', you can link the script to a specific category by using the format: '<kbd>google_cookies:*youtube.com</kbd>'.<br><br>Any embed not explicitly blocked is allowed. To alter this behaviour, finish with a <kbd>*</kbd> rule."),
   ];
-
-
 
   $form['#submit'][] = '_localgov_eu_cookie_compliance_path_submit';
 }
-
-
-/**
- * Based on the implementation at https://git.drupalcode.org/project/cookies/-/blob/2.x/modules/cookies_video/cookies_video.module
- *
- * Implements hook_preprocess_HOOK().
- */
-function localgov_eu_cookie_compliance_preprocess_field(&$variables) {
-  $formatter = $variables["element"]["#formatter"];
-  if ($formatter === 'oembed') {
-    _cookies_video_media_oembed_handler($variables);
-  }
-}
-
-
 
 /**
  * Implements hook_page_attachments_alter().
@@ -256,6 +249,17 @@ function _localgov_eu_cookie_compliance_defer_tracker_scripts(array &$attachment
   $attachment_list['#attached']['drupalSettings']['deferred_scripts'] = json_encode($deferred_head_items_markup);
 }
 
+/**
+ * Based on the implementation at https://git.drupalcode.org/project/cookies/-/blob/2.x/modules/cookies_video/cookies_video.module under GPLv2.
+ *
+ * Implements hook_preprocess_HOOK().
+ */
+function localgov_eu_cookie_compliance_preprocess_field(&$variables) {
+  $formatter = $variables["element"]["#formatter"];
+  if ($formatter === 'oembed') {
+    localgov_eu_cookie_compliance_media_oembed_handler($variables);
+  }
+}
 
 /**
  * Handling oembed field formatters.
@@ -263,79 +267,105 @@ function _localgov_eu_cookie_compliance_defer_tracker_scripts(array &$attachment
  * @param array $variables
  *   Field template variables (s. cookies_video_preprocess_field()).
  */
-function _cookies_video_media_oembed_handler(array &$variables) {
+function localgov_eu_cookie_compliance_media_oembed_handler(array &$variables) {
   $formatter = $variables["element"]["#formatter"];
-    /** @var \Drupal\Core\Field\FieldItemList $field_item */
-    $field_item = $variables['element']['#items'];
-    /** @var \Drupal\media\Entity\Media $media */
-    $media = $variables['element']['#object'];
-    $media_id = $media->id();
-    $variables['attributes']['class'][] = "media-oembed-$media_id";
-    $field_value = $field_item->getValue();
-    if (isset($field_value) && !empty($field_value)) {
-      $field_value = reset($field_value);
-      $video_src = $field_value['value'];
-    }
-    
-    $oembed_settings = Drupal::config('localgov_eu_cookie_compliance.settings')->get('disabled_oembeds') ?? [];
-    $disabled_oembeds = _eu_cookie_compliance_explode_multiple_lines($oembed_settings);
-    $blocked_domains = array();
-    foreach ($disabled_oembeds as $embed) {
-      // Remove 'category:' if present.
-      $parts = explode('%3A', $embed);
-      if (count($parts) == 1) {
-        $condition = "";
-        $embed = $parts[0];
-      }
-      else {
-        $condition = $parts[0];
-        $embed = end($parts);
-      }
-      $blocked_domains[$embed] = $condition;
-    }
+  /** @var \Drupal\Core\Field\FieldItemList $field_item */
+  $field_item = $variables['element']['#items'];
+  /** @var \Drupal\media\Entity\Media $media */
+  $media = $variables['element']['#object'];
+  $media_id = $media->id();
+  $variables['attributes']['class'][] = "media-oembed-$media_id";
+  $field_value = $field_item->getValue();
+  if (isset($field_value) && !empty($field_value)) {
+    $field_value = reset($field_value);
+    $video_src = $field_value['value'];
+  }
 
-    foreach ($variables["items"] as &$item) {
-      switch ($formatter) {
-        case 'oembed':
-          $item["content"]["#attributes"]['data-src'] = $video_src;
+  // Get the oembed settings lines and split them out.
+  $oembed_settings = Drupal::config('localgov_eu_cookie_compliance.settings')->get('disabled_oembeds') ?? "";
+  $disabled_oembeds = explode("\n", trim($oembed_settings));
 
-          $parsed = parse_url($video_src);
-          
-          if (in_array($parsed["host"], array_keys($blocked_domains))) {
-            $condition = $blocked_domains[$parsed["host"]];
-            $video = _cookies_video_preprocess_field_item_oembed($item);
-            // render default as link element
-            _cookies_video_preprocess_field_item_link($item);
+  // Convert the domains with optional category into an associative
+  // array of domain to category.
+  $blocked_domains = [];
+  foreach ($disabled_oembeds as $embed) {
+    // Extract the category condition, if present.
+    $parts = explode(':', $embed);
+    if (count($parts) == 1) {
+      $condition = "";
+      $embed = $parts[0];
+    }
+    else {
+      $condition = $parts[0];
+      $embed = end($parts);
+    }
+    $blocked_domains[$embed] = $condition;
+  }
+
+  foreach ($variables["items"] as &$item) {
+    switch ($formatter) {
+      case 'oembed':
+        // Get the video src being embedded.
+        $item["content"]["#attributes"]['data-src'] = $video_src;
+        $parsed = parse_url($video_src);
+
+        // Check against each rule.
+        foreach ($blocked_domains as $domain => $condition) {
+          // Convert the domain specification to a regex by:
+          // 1. Trim and quote the entered domain.
+          // 2. Replace * and ? with .* and . respectively.
+          // 3. Wrap in a case-insensitive search.
+          $regex = str_replace(
+            "\\?",
+            ".",
+            str_replace(
+              "\\*",
+              ".*",
+              preg_quote(trim($domain))
+            )
+          );
+          $regex = "/" . $regex . "/i";
+
+          // If the built regex matches, replace this item.
+          if (preg_match($regex, $parsed["host"])) {
+            // Add a class to the generated video markup.
+            $video = localgov_eu_cookie_compliance_preprocess_field_item_oembed($item);
+            // Render a link instead.
+            localgov_eu_cookie_compliance_preprocess_field_item_link($item);
+            // Record the video markup in the page JSON along with the condition.
+            $elements = [
+              $media->id() => [
+                'video' => Drupal::service('renderer')->render($video, FALSE),
+                'category' => $condition,
+              ],
+            ];
+            // Do not process more rules if one matched.
+            break;
           }
-          
-          $elements = [
-            $media->id() => [
-              'video' => Drupal::service('renderer')->render($video, FALSE),
-              'category' => $condition,
-            ]
-          ];
-          break;
+        }
+        // End of oembed case.
+        break;
 
-        default:
-      }
-
-      // Attach library.
-      if (!isset($item["content"]["#attached"])) {
-        $item["content"]["#attached"] = ["library" => []];
-      }
-      if (!isset($item["content"]["#attached"]["library"])) {
-        $item["content"]["#attached"]["library"] = [];
-      }
-      $variables["#attached"]["library"][] = 'localgov_eu_cookie_compliance/oembed_cookies';
-      $variables['#attached']['drupalSettings']['ecc_cookie_oembed'] = $elements;
+      // Not an oembed.
+      default:
     }
+
+    // Attach handler library.
+    if (!isset($item["content"]["#attached"])) {
+      $item["content"]["#attached"] = ["library" => []];
+    }
+    if (!isset($item["content"]["#attached"]["library"])) {
+      $item["content"]["#attached"]["library"] = [];
+    }
+    $variables["#attached"]["library"][] = 'localgov_eu_cookie_compliance/oembed_cookies';
+    $variables['#attached']['drupalSettings']['ecc_cookie_oembed'] = $elements;
+  }
 }
 
-
 /**
- * Handling field_item from oembed formatter.
+ * Mark video embed with cookies-video class.
  */
-function _cookies_video_preprocess_field_item_oembed(&$item) {
+function localgov_eu_cookie_compliance_preprocess_field_item_oembed(&$item) {
   // Set marker class.
   if (!isset($item["content"]["#attributes"]["class"]) || !is_array($item["content"]["#attributes"]["class"])) {
     $item["content"]["#attributes"]["class"] = [];
@@ -345,7 +375,10 @@ function _cookies_video_preprocess_field_item_oembed(&$item) {
   return $item['content'];
 }
 
-function _cookies_video_preprocess_field_item_link(&$item) {
+/**
+ * Generate a link to new window for video as fallback.
+ */
+function localgov_eu_cookie_compliance_preprocess_field_item_link(&$item) {
   // Move src to href.
   $src = $item["content"]["#attributes"]["data-src"];
   $title = $item["content"]["#attributes"]["title"];

--- a/localgov_eu_cookie_compliance.module
+++ b/localgov_eu_cookie_compliance.module
@@ -116,8 +116,44 @@ function localgov_eu_cookie_compliance_form_eu_cookie_compliance_config_form_alt
     '#convert_path' => PathElement::CONVERT_NONE,
   ];
 
+
+  $form['oembed'] = [
+    '#type' => 'details',
+    '#title' => t("Disable the following embed sources when consent isn't given"),
+    '#open' => TRUE,
+    '#states' => [
+      'visible' => [
+        "input[name='method']" => ['!value' => 'default'],
+      ],
+    ],
+  ];
+
+  $form['oembed']['disabled_oembeds'] = [
+    '#type' => 'textarea',
+    '#title' => t('Disable OEmbed sources'),
+    '#default_value' => $config->get('disabled_oembeds'),
+    '#description' => t("<span class='eu-cookie-compliance-word-break'>Include the domain to block embeds from, each on a separate line. When using the opt-in or opt-out consent options, you can block certain oembed sources from being loaded when consent isn't given.<br><br> When using the consent method 'Opt-in with categories', you can link the script to a specific category by using the format: 'google_cookies:youtu.be'"),
+  ];
+
+
+
   $form['#submit'][] = '_localgov_eu_cookie_compliance_path_submit';
 }
+
+
+/**
+ * Based on the implementation at https://git.drupalcode.org/project/cookies/-/blob/2.x/modules/cookies_video/cookies_video.module
+ *
+ * Implements hook_preprocess_HOOK().
+ */
+function localgov_eu_cookie_compliance_preprocess_field(&$variables) {
+  $formatter = $variables["element"]["#formatter"];
+  if ($formatter === 'oembed') {
+    _cookies_video_media_oembed_handler($variables);
+  }
+}
+
+
 
 /**
  * Implements hook_page_attachments_alter().
@@ -136,12 +172,14 @@ function localgov_eu_cookie_compliance_page_attachments_alter(array &$attachment
 function _localgov_eu_cookie_compliance_path_submit(array &$form, FormStateInterface $form_state) {
 
   $cookie_settings_page_path = $form_state->getValue('cookie-settings-page-path');
+  $disabled_oembeds = $form_state->getValue('disabled_oembeds');
   $path_w_leading_slash = '/' . trim($cookie_settings_page_path, '/');
 
   $config_factory = \Drupal::service('config.factory');
   $config = $config_factory->getEditable('localgov_eu_cookie_compliance.settings');
 
   $config->set('cookie-settings-page-path', $path_w_leading_slash);
+  $config->set('disabled_oembeds', $disabled_oembeds);
   $config->save();
 }
 
@@ -216,4 +254,107 @@ function _localgov_eu_cookie_compliance_defer_tracker_scripts(array &$attachment
   }, []);
 
   $attachment_list['#attached']['drupalSettings']['deferred_scripts'] = json_encode($deferred_head_items_markup);
+}
+
+
+/**
+ * Handling oembed field formatters.
+ *
+ * @param array $variables
+ *   Field template variables (s. cookies_video_preprocess_field()).
+ */
+function _cookies_video_media_oembed_handler(array &$variables) {
+  $formatter = $variables["element"]["#formatter"];
+    /** @var \Drupal\Core\Field\FieldItemList $field_item */
+    $field_item = $variables['element']['#items'];
+    /** @var \Drupal\media\Entity\Media $media */
+    $media = $variables['element']['#object'];
+    $media_id = $media->id();
+    $variables['attributes']['class'][] = "media-oembed-$media_id";
+    $field_value = $field_item->getValue();
+    if (isset($field_value) && !empty($field_value)) {
+      $field_value = reset($field_value);
+      $video_src = $field_value['value'];
+    }
+    
+    $oembed_settings = Drupal::config('localgov_eu_cookie_compliance.settings')->get('disabled_oembeds') ?? [];
+    $disabled_oembeds = _eu_cookie_compliance_explode_multiple_lines($oembed_settings);
+    $blocked_domains = array();
+    foreach ($disabled_oembeds as $embed) {
+      // Remove 'category:' if present.
+      $parts = explode('%3A', $embed);
+      if (count($parts) == 1) {
+        $condition = "";
+        $embed = $parts[0];
+      }
+      else {
+        $condition = $parts[0];
+        $embed = end($parts);
+      }
+      $blocked_domains[$embed] = $condition;
+    }
+
+    foreach ($variables["items"] as &$item) {
+      switch ($formatter) {
+        case 'oembed':
+          $item["content"]["#attributes"]['data-src'] = $video_src;
+
+          $parsed = parse_url($video_src);
+          
+          if (in_array($parsed["host"], array_keys($blocked_domains))) {
+            $condition = $blocked_domains[$parsed["host"]];
+            $video = _cookies_video_preprocess_field_item_oembed($item);
+            // render default as link element
+            _cookies_video_preprocess_field_item_link($item);
+          }
+          
+          $elements = [
+            $media->id() => [
+              'video' => Drupal::service('renderer')->render($video, FALSE),
+              'category' => $condition,
+            ]
+          ];
+          break;
+
+        default:
+      }
+
+      // Attach library.
+      if (!isset($item["content"]["#attached"])) {
+        $item["content"]["#attached"] = ["library" => []];
+      }
+      if (!isset($item["content"]["#attached"]["library"])) {
+        $item["content"]["#attached"]["library"] = [];
+      }
+      $variables["#attached"]["library"][] = 'localgov_eu_cookie_compliance/oembed_cookies';
+      $variables['#attached']['drupalSettings']['ecc_cookie_oembed'] = $elements;
+    }
+}
+
+
+/**
+ * Handling field_item from oembed formatter.
+ */
+function _cookies_video_preprocess_field_item_oembed(&$item) {
+  // Set marker class.
+  if (!isset($item["content"]["#attributes"]["class"]) || !is_array($item["content"]["#attributes"]["class"])) {
+    $item["content"]["#attributes"]["class"] = [];
+  }
+  $item["content"]["#attributes"]["class"][] = 'cookies-video';
+
+  return $item['content'];
+}
+
+function _cookies_video_preprocess_field_item_link(&$item) {
+  // Move src to href.
+  $src = $item["content"]["#attributes"]["data-src"];
+  $title = $item["content"]["#attributes"]["title"];
+  $item["content"]["#attributes"] = [];
+
+  $item["content"]["#type"] = "html_tag";
+  $item["content"]["#tag"] = "a";
+  $item["content"]["#attributes"]["href"] = $src;
+  $item["content"]["#attributes"]["title"] = $title;
+  $item["content"]["#attributes"]["target"] = "_blank";
+  $item["content"]["#value"] = $title;
 }


### PR DESCRIPTION
This adds the oembed blocking functionality from ECC. The code is derived from COOKiES Video, under GPL2. It is integrated with eu_cookie_compliance with support for categories.

OEmbed video is allowed by default, with blocking by consent possible to be set on a domain basis, including wildcards. These wildcards are read in order, allowing a catch-all block to prevent unintended embeds from loading. These embeds are replaced at page render time, so it may be necessary to clear render caches after changing cookie compliance settings.