### PR TITLE
Vary cache id based if it's on the setting page or not.

### DIFF
--- a/localgov_eu_cookie_compliance.module
+++ b/localgov_eu_cookie_compliance.module
@@ -99,6 +99,15 @@ function localgov_eu_cookie_compliance_eu_cookie_compliance_show_popup_alter(&$s
 }
 
 /**
+ * Implements hook_eu_cookie_compliance_cid_alter().
+ *
+ * Add if this is the cookie page, or not, to the cache id.
+ */
+function localgov_eu_cookie_compliance_eu_cookie_compliance_cid_alter(&$cid) {
+  $cid .= (_localgov_eu_cookie_compliance_is_cookie_settings_page() ? ':settings_page' : ':banner');
+}
+
+/**
  * Implements hook_form_FORM_ID_alter() for hook_form_eu_cookie_compliance_config_form_alter().
  *
  * Alterations:


### PR DESCRIPTION
Reports (from Greenwich) that in some cases when /cookies was the first time the cookie options was being displayed it would be displayed in the same way (with the categories expanded) in the banner. This fixes that in my quick testing.

This modules block varies the cached output by the page it's on https://github.com/localgovdrupal/localgov_eu_cookie_compliance/blob/24bba7b48a1b9c9c0136a20f7e007c27a3d57920/src/Plugin/Block/CookieSettings.php#L47 but the content being generated https://github.com/localgovdrupal/localgov_eu_cookie_compliance/blob/24bba7b48a1b9c9c0136a20f7e007c27a3d57920/src/Plugin/Block/CookieSettings.php#L35 is always the same https://git.drupalcode.org/project/eu-cookie-compliance/-/blob/8.x-1.x/eu_cookie_compliance.module?ref_type=heads#L173 but can be varied https://git.drupalcode.org/project/eu-cookie-compliance/-/blob/8.x-1.x/eu_cookie_compliance.module?ref_type=heads#L171

